### PR TITLE
Add permalink to setlist

### DIFF
--- a/src/Setlistbot.Domain.Kglw/DiscordReplyBuilder.cs
+++ b/src/Setlistbot.Domain.Kglw/DiscordReplyBuilder.cs
@@ -64,9 +64,15 @@ namespace Setlistbot.Domain.Kglw
                 reply.Append(Environment.NewLine);
             }
 
-            reply.Append("> _data provided by [kglw.net](http://kglw.net)_");
+            var kglwNetUrl = GetKglwNetUrl(setlist);
+            reply.Append($"> _data provided by [kglw.net]({kglwNetUrl})_");
 
             return reply.ToString();
+        }
+
+        private string GetKglwNetUrl(Setlist setlist)
+        {
+            return $"https://kglw.net/setlists/{setlist.Permalink}";
         }
     }
 }

--- a/src/Setlistbot.Domain.Kglw/RedditReplyBuilder.cs
+++ b/src/Setlistbot.Domain.Kglw/RedditReplyBuilder.cs
@@ -85,14 +85,15 @@ namespace Setlistbot.Domain.Kglw
                 reply.Append(Environment.NewLine);
             }
 
-            reply.Append($"> _data provided by [kglw.net](https://kglw.net)_");
+            var kglwNetUrl = GetKglwNetUrl(setlist);
+            reply.Append($"> _data provided by [kglw.net]({kglwNetUrl})_");
 
             return reply.ToString();
         }
 
         private string GetKglwNetUrl(Setlist setlist)
         {
-            return $"http://kglw.today/{setlist.Date.ToString("yyyy-MM-dd")}";
+            return $"https://kglw.net/setlists/{setlist.Permalink}";
         }
     }
 }

--- a/src/Setlistbot.Domain/Setlist.cs
+++ b/src/Setlistbot.Domain/Setlist.cs
@@ -14,7 +14,8 @@ namespace Setlistbot.Domain
         public Location Location { get; private set; } = null!;
         public int Duration => Sets.Sum(s => s.Duration);
         public string Notes { get; private set; } = string.Empty;
-        public string SpotifyUrl { get; private set; } = string.Empty;
+        public string? SpotifyUrl { get; private set; }
+        public string? Permalink { get; private set; }
 
         private Setlist() { }
 
@@ -60,8 +61,13 @@ namespace Setlistbot.Domain
         public void AddSpotifyUrl(Uri url)
         {
             Ensure.That(url, nameof(url)).IsNotNull();
-
             SpotifyUrl = url.ToString();
+        }
+
+        public void AddPermalink(Uri url)
+        {
+            Ensure.That(url, nameof(url)).IsNotNull();
+            Permalink = url.ToString();
         }
     }
 }

--- a/src/Setlistbot.Infrastructure.KglwNet/KglwNetSetlistProvider.cs
+++ b/src/Setlistbot.Infrastructure.KglwNet/KglwNetSetlistProvider.cs
@@ -56,7 +56,8 @@ namespace Setlistbot.Infrastructure.KglwNet
                                 s.City,
                                 s.State,
                                 s.Country,
-                                s.ShowNotes
+                                s.ShowNotes,
+                                s.Permalink
                             }
                     )
                     .OrderBy(s => s.Key.ShowDate)

--- a/src/Setlistbot.Infrastructure.KglwNet/SetlistResponse.cs
+++ b/src/Setlistbot.Infrastructure.KglwNet/SetlistResponse.cs
@@ -54,5 +54,8 @@ namespace Setlistbot.Infrastructure.KglwNet
 
         [JsonProperty("shownotes")]
         public string ShowNotes { get; set; } = string.Empty;
+
+        [JsonProperty("permalink")]
+        public string Permalink { get; set; } = string.Empty;
     }
 }

--- a/test/Setlistbot.Domain.Kglw/RedditReplyBuilderTests.cs
+++ b/test/Setlistbot.Domain.Kglw/RedditReplyBuilderTests.cs
@@ -66,6 +66,12 @@ namespace Setlistbot.Domain.Kglw.UnitTests
 
             setlist.AddSet(set2);
 
+            var permalink = new Uri(
+                "king-gizzard-the-lizard-wizard-october-10-2022-red-rocks-amphitheatre-morrison-co-usa.html",
+                UriKind.Relative
+            );
+            setlist.AddPermalink(permalink);
+
             var builder = new RedditReplyBuilder();
 
             // Act

--- a/test/Setlistbot.Domain.Kglw/TestData/2022-10-11-reply.md
+++ b/test/Setlistbot.Domain.Kglw/TestData/2022-10-11-reply.md
@@ -4,4 +4,4 @@
 
 **Set 2:**  Perihelion > I'm in Your Mind > I'm Not in Your Mind > Cellophane > I'm in Your Mind Fuzz, Tezeta, A New World > Altered Beast I > Alter Me I > Altered Beast II > Alter Me II > Altered Beast III > Ambergris, Muddy Water, Iron Lung, Robot Stop > Gamma Knife > People-Vultures > Mr. Beat -> Iron Lung 
 
-> _data provided by [kglw.net](https://kglw.net)_
+> _data provided by [kglw.net](https://kglw.net/setlists/king-gizzard-the-lizard-wizard-october-10-2022-red-rocks-amphitheatre-morrison-co-usa.html)_


### PR DESCRIPTION
Fixes #27 

This change adds `Permalink` to the `Setlist` domain object. It also updates the kglw.net link to use the permalink value.