### PR TITLE
Use the OAuth endpoint to get new posts.

### DIFF
--- a/src/Setlistbot.Infrastructure.Reddit/IRedditClient.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/IRedditClient.cs
@@ -7,6 +7,6 @@ namespace Setlistbot.Infrastructure.Reddit
         Task<string?> GetAuthToken(string username, string password, string key, string secret);
         Task<SubredditCommentsResponse?> GetComments(string subreddit, int? limit = default);
         Task<PostCommentResponse?> PostComment(string token, string parent, string text);
-        Task<SubredditPostsResponse?> GetPosts(string subreddit);
+        Task<SubredditPostsResponse?> GetPosts(string token, string subreddit);
     }
 }

--- a/src/Setlistbot.Infrastructure.Reddit/RedditClient.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/RedditClient.cs
@@ -108,7 +108,13 @@ namespace Setlistbot.Infrastructure.Reddit
             return response;
         }
 
-        public async Task<SubredditPostsResponse?> GetPosts(string subreddit)
+        /// <summary>
+        /// Gets the last 25 posts for a subreddit
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="subreddit"></param>
+        /// <returns></returns>
+        public async Task<SubredditPostsResponse?> GetPosts(string token, string subreddit)
         {
             Ensure.That(subreddit, nameof(subreddit)).IsNotNullOrWhiteSpace();
 
@@ -116,9 +122,10 @@ namespace Setlistbot.Infrastructure.Reddit
 
             try
             {
-                var url = $"https://www.reddit.com/r/{subreddit}/new.json";
+                var url = $"https://oauth.reddit.com/r/{subreddit}/new";
 
                 response = await url.WithHeader("User-Agent", "setlistbot")
+                    .WithOAuthBearerToken(token)
                     .GetJsonAsync<SubredditPostsResponse>();
             }
             catch (FlurlHttpException ex)

--- a/src/Setlistbot.Infrastructure.Reddit/RedditService.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/RedditService.cs
@@ -62,7 +62,13 @@ namespace Setlistbot.Infrastructure.Reddit
 
             try
             {
-                var response = await _client.GetPosts(subreddit);
+                var token = await GetAuthToken();
+                if (token == null)
+                {
+                    return Enumerable.Empty<Post>();
+                }
+
+                var response = await _client.GetPosts(token, subreddit);
                 if (response != null)
                 {
                     return response.Data.Children
@@ -95,13 +101,7 @@ namespace Setlistbot.Infrastructure.Reddit
 
             try
             {
-                var token = await _client.GetAuthToken(
-                    _redditOptions.Username,
-                    _redditOptions.Password,
-                    _redditOptions.Key,
-                    _redditOptions.Secret
-                );
-
+                var token = await GetAuthToken();
                 if (token == null)
                 {
                     return false;
@@ -116,6 +116,16 @@ namespace Setlistbot.Infrastructure.Reddit
             }
 
             return false;
+        }
+
+        private async Task<string?> GetAuthToken()
+        {
+            return await _client.GetAuthToken(
+                _redditOptions.Username,
+                _redditOptions.Password,
+                _redditOptions.Key,
+                _redditOptions.Secret
+            );
         }
     }
 }


### PR DESCRIPTION
Changes the API call to get new posts to use the OAuth endpoint which should help keep setlistbot under quota. The previous API call was not using OAuth and was subject to 10 RPM.


> Free API access rates are as follows:
> 100 queries per minute per OAuth client id if you are using OAuth authentication
> 10 queries per minute if you are not using OAuth authentication