### PR TITLE
Use OAuth endpoint to get comments

### DIFF
--- a/src/Setlistbot.Infrastructure.Reddit/IRedditClient.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/IRedditClient.cs
@@ -5,7 +5,11 @@ namespace Setlistbot.Infrastructure.Reddit
     public interface IRedditClient
     {
         Task<string?> GetAuthToken(string username, string password, string key, string secret);
-        Task<SubredditCommentsResponse?> GetComments(string subreddit, int? limit = default);
+        Task<SubredditCommentsResponse?> GetComments(
+            string token,
+            string subreddit,
+            int? limit = default
+        );
         Task<PostCommentResponse?> PostComment(string token, string parent, string text);
         Task<SubredditPostsResponse?> GetPosts(string token, string subreddit);
     }

--- a/src/Setlistbot.Infrastructure.Reddit/RedditClient.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/RedditClient.cs
@@ -69,6 +69,7 @@ namespace Setlistbot.Infrastructure.Reddit
         /// <param name="limit">The number of comments to take</param>
         /// <returns>The deserialized response from the API if successful</returns>
         public async Task<SubredditCommentsResponse?> GetComments(
+            string token,
             string subreddit,
             int? limit = default
         )
@@ -85,7 +86,7 @@ namespace Setlistbot.Infrastructure.Reddit
             try
             {
                 // 25 is the default limit if no 'limit' query parameter is supplied
-                var url = $"https://www.reddit.com/r/{subreddit}/comments.json";
+                var url = $"https://oauth.reddit.com/r/{subreddit}/comments.json";
 
                 if (limit.HasValue)
                 {
@@ -93,6 +94,7 @@ namespace Setlistbot.Infrastructure.Reddit
                 }
 
                 response = await url.WithHeader("User-Agent", "setlistbot")
+                    .WithOAuthBearerToken(token)
                     .GetJsonAsync<SubredditCommentsResponse>();
             }
             catch (FlurlHttpException ex)

--- a/src/Setlistbot.Infrastructure.Reddit/RedditService.cs
+++ b/src/Setlistbot.Infrastructure.Reddit/RedditService.cs
@@ -31,7 +31,17 @@ namespace Setlistbot.Infrastructure.Reddit
 
             try
             {
-                var response = await _client.GetComments(subreddit, _redditOptions.CommentsLimit);
+                var token = await GetAuthToken();
+                if (token == null)
+                {
+                    return Enumerable.Empty<Comment>();
+                }
+
+                var response = await _client.GetComments(
+                    token,
+                    subreddit,
+                    _redditOptions.CommentsLimit
+                );
                 if (response != null)
                 {
                     return response.Data.Children


### PR DESCRIPTION
This change converts the endpoint to get comments for a subreddit to use the OAuth endpoint instead of the unauthenticated endpoint.

Related to #30 