### PR TITLE
fix: update default log level to Warning

### DIFF
--- a/src/Setlistbot.Function.Discord/host.json
+++ b/src/Setlistbot.Function.Discord/host.json
@@ -2,7 +2,11 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Information"
+      "default": "Warning",
+      "Host.Results": "Information",
+      "Function": "Information",
+      "Host.Aggregator": "Information",
+      "Setlistbot": "Information"
     }
   }
 }

--- a/src/Setlistbot.Function.RedditBot/host.json
+++ b/src/Setlistbot.Function.RedditBot/host.json
@@ -2,7 +2,11 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Information"
+      "default": "Warning",
+      "Host.Results": "Information",
+      "Function": "Information",
+      "Host.Aggregator": "Information",
+      "Setlistbot": "Information"
     }
   }
 }


### PR DESCRIPTION
Explicitly allow information level logging for namespaces.